### PR TITLE
Add missing ring-codec and bump tufte in example project

### DIFF
--- a/examples/clj/project.clj
+++ b/examples/clj/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso.examples/tufte "2.7.0"
+(defproject com.taoensso.examples/tufte "3.0.0"
   :description "Tufte example web-app project"
   :url "https://github.com/ptaoussanis/tufte"
   :main    example.server
@@ -7,6 +7,7 @@
   [[org.clojure/clojure "1.12.0"]
    [ring                "1.14.1"]
    [ring/ring-defaults  "0.6.0"]
+   [ring/ring-codec     "1.3.0"]
    [compojure           "1.7.1"]
    [hiccup              "1.0.5"]
-   [com.taoensso/tufte  "2.7.0"]])
+   [com.taoensso/tufte  "3.0.0"]])


### PR DESCRIPTION
Thank you for creating the `tufte` library.

I tried running the example project and found that it didn't run out of the box:

- missing the ring-codec library
- `tufte/handler:accumulating` var was only available in 3.0.0

This PR addresses the minor issues found.